### PR TITLE
description text better matches behaviour

### DIFF
--- a/R/inside_mask.R
+++ b/R/inside_mask.R
@@ -2,9 +2,10 @@
 #' @title title
 #' @description  Checks whether longitude and latitude coincide with
 #' non-missing pixels of a raster. The function takes two arguments:
-#' points, a dataframe containing columns named
-#' longitude' and 'latitude', and mask is a raster. Returns a dataframe
-#' of longitude and latitude only those rows with points falling on
+#' points, a dataframe containing at a minimum columns named
+#' longitude' and 'latitude' (but could include other attributes),
+#' and mask is a raster. Returns a dataframe of the same dimensions as the
+#' input object, containing only those rows with points falling on
 #' non-missing pixels. If all points fall on missing pixels,
 #' the function throws an error.
 #'


### PR DESCRIPTION
Text indicated that only the coordinates would be returned, suggesting that a join would be required to reattach result to other data, but the function will return same dimensions as input data frame. 